### PR TITLE
Add auto-number support for Headings Level 5 and 6.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Follow two simple steps to auto-number your section titles:
 1. Format your section titles as headings.
 2. Run "Auto-number headings" from the menu of Referencer.
 
-Heading is a built-in style for titles in Google Docs. To enable auto-numbering of section titles, you need to firstly style them as headings. There are four levels of headings supported by Google Docs. If you need help with using headings in Google Docs, please visit [Docs Editor Help](https://support.google.com/docs/answer/116338?hl=en&co=GENIE.Platform=Desktop).
+Heading is a built-in style for titles in Google Docs. To enable auto-numbering of section titles, you need to firstly style them as headings. There are six levels of headings supported by Google Docs. If you need help with using headings in Google Docs, please visit [Docs Editor Help](https://support.google.com/docs/answer/116338?hl=en&co=GENIE.Platform=Desktop).
 
 ## Update references
 

--- a/heading.gs
+++ b/heading.gs
@@ -12,7 +12,9 @@ const heading1 = DocumentApp.ParagraphHeading.HEADING1;
 const heading2 = DocumentApp.ParagraphHeading.HEADING2;
 const heading3 = DocumentApp.ParagraphHeading.HEADING3;
 const heading4 = DocumentApp.ParagraphHeading.HEADING4;
-const headingTypes = new Set([heading1, heading2, heading3, heading4]);
+const heading5 = DocumentApp.ParagraphHeading.HEADING5;
+const heading6 = DocumentApp.ParagraphHeading.HEADING6;
+const headingTypes = new Set([heading1, heading2, heading3, heading4, heading5, heading6]);
 
 
 /**
@@ -104,7 +106,9 @@ function numberHeadings() {
  *                               numHeading1,
  *                               numHeading2,
  *                               numHeading3,
- *                               numHeading4
+ *                               numHeading4,
+ *                               numHeading5,
+ *                               numHeading6
  *                               }
  */
 function getHeadings() {
@@ -117,6 +121,8 @@ function getHeadings() {
   var numHeading2 = 0;
   var numHeading3 = 0;
   var numHeading4 = 0;
+  var numHeading5 = 0;
+  var numHeading6 = 0;
 
   while (searchResult = ps.findElement(searchType, searchResult)) {
     var par = searchResult.getElement().asParagraph();
@@ -131,27 +137,46 @@ function getHeadings() {
         numHeading2 = 0;
         numHeading3 = 0;
         numHeading4 = 0;
+        numHeading5 = 0;
+        numHeading6 = 0;
       }
 
       if (h == heading2) {
         numHeading2++;
         numHeading3 = 0;
         numHeading4 = 0;
+        numHeading5 = 0;
+        numHeading6 = 0;
       }
 
       if (h == heading3) {
         numHeading3++;
         numHeading4 = 0;
+        numHeading5 = 0;
+        numHeading6 = 0;
       }
 
       if (h == heading4) {
         numHeading4++;
+        numHeading5 = 0;
+        numHeading6 = 0;
+      }
+
+      if (h == heading5) {
+        numHeading5++;
+        numHeading6 = 0;
+      }
+
+      if (h == heading6) {
+        numHeading6++;
       }
 
       parObj.heading1 = numHeading1;
       parObj.heading2 = numHeading2;
       parObj.heading3 = numHeading3;
       parObj.heading4 = numHeading4;
+      parObj.heading5 = numHeading5;
+      parObj.heading6 = numHeading6;
 
       results.push(parObj);
     }
@@ -183,6 +208,14 @@ function getNumberStr(parObj) {
   if (parObj.heading4 != 0) {
     result += '.' + parObj.heading4;
   }
+
+  if (parObj.heading5 != 0) {
+    result += '.' + parObj.heading5;
+  }
+
+  if (parObj.heading6 != 0) {
+    result += '.' + parObj.heading6;
+  }  
 
   return result + ' ';
 }


### PR DESCRIPTION
Google Docs supports up to heading level 5 and 6 as long as you're using the preceding levels within your document.